### PR TITLE
fix: preserve all genes per shared TSS peak in RegionMotif

### DIFF
--- a/get_model/dataset/zarr_dataset.py
+++ b/get_model/dataset/zarr_dataset.py
@@ -2,6 +2,7 @@ import logging
 import os
 import os.path
 import warnings
+from collections import defaultdict
 from dataclasses import dataclass
 from posixpath import basename
 from typing import Callable, Dict, List, Optional, Tuple
@@ -911,7 +912,7 @@ class RegionMotif:
             self.atpm = self.atpm[atpm_nonzero_idx]
             self.peak_names = self.peak_names[atpm_nonzero_idx]
             self.data = self.data[atpm_nonzero_idx]
-            self._peaks = self._peaks.iloc[atpm_nonzero_idx]
+            self._peaks = self._peaks.iloc[atpm_nonzero_idx].reset_index(drop=True)
 
         if f"expression_positive/{self.celltype}" in self.dataset:
             self.expression_positive = self.dataset[
@@ -932,16 +933,24 @@ class RegionMotif:
                 self.expression_negative = self.expression_negative[atpm_nonzero_idx]
                 self.tss = self.tss[atpm_nonzero_idx]
                 gene_idx_info_drop_zero_atpm = []
-                idx_to_iloc = {v: i for i, v in enumerate(gene_idx_info_index)}
+                # Build a one-to-many mapping so that multiple genes sharing
+                # the same TSS peak are all preserved.  The previous dict-based
+                # approach ({v: i for i, v in enumerate(...)}) silently dropped
+                # all but the last gene for any peak that hosts more than one
+                # gene's promoter.
+                idx_to_ilocs = defaultdict(list)
+                for i, v in enumerate(gene_idx_info_index):
+                    idx_to_ilocs[v].append(i)
                 for idx_non_zero_atpm, idx in enumerate(atpm_nonzero_idx):
-                    if idx in idx_to_iloc:
-                        gene_idx_info_drop_zero_atpm.append(
-                            (
-                                idx_non_zero_atpm,
-                                gene_idx_info_name[idx_to_iloc[idx]],
-                                gene_idx_info_strand[idx_to_iloc[idx]],
+                    if idx in idx_to_ilocs:
+                        for pos in idx_to_ilocs[idx]:
+                            gene_idx_info_drop_zero_atpm.append(
+                                (
+                                    idx_non_zero_atpm,
+                                    gene_idx_info_name[pos],
+                                    gene_idx_info_strand[pos],
+                                )
                             )
-                        )
                 self.gene_idx_info = pd.DataFrame(
                     gene_idx_info_drop_zero_atpm,
                     columns=["index", "gene_name", "strand"],
@@ -1232,6 +1241,8 @@ class InferenceRegionMotifDataset(RegionMotifDataset):
                 strand = 0 if strand == "+" else 1
                 tss_peaks = gene_df["index"].values
                 chrom = region_motif.peaks.iloc[tss_peaks[0]]["Chromosome"]
+                if chrom not in input_chromosomes:
+                    continue
                 # Process each TSS for the gene
                 for tss_idx in tss_peaks:
                     start_idx = tss_idx - self.num_region_per_sample // 2

--- a/get_model/utils.py
+++ b/get_model/utils.py
@@ -69,11 +69,20 @@ def setup_trainer(cfg):
             )
         )
     )
+    # Expression finetuning logs `val_exp_loss` rather than `val_loss`.
+    checkpoint_monitor = cfg.training.get("checkpoint_monitor", "val_exp_loss")
+
     # Create both regular and finetuned checkpoints
     save_top_k = -1 if cfg.training.save_every_n_epochs is not None else 1
-    filename = "checkpoint-{epoch:03d}-{step:06d}-{val_loss:.4f}" if cfg.training.save_every_n_epochs is not None else "best"
+    if cfg.training.save_every_n_epochs is not None:
+        if checkpoint_monitor == "val_exp_loss":
+            filename = "checkpoint-{epoch:03d}-{step:06d}-{val_exp_loss:.4f}"
+        else:
+            filename = f"checkpoint-{{epoch:03d}}-{{step:06d}}-{{{checkpoint_monitor}:.4f}}"
+    else:
+        filename = "best"
     regular_checkpoint = ModelCheckpoint(
-        monitor="val_loss",
+        monitor=checkpoint_monitor,
         mode="min",
         save_top_k=save_top_k,
         save_last=True,


### PR DESCRIPTION
## Bug

`RegionMotif._load_celltype_data` builds a lookup from peak index to
position in `gene_idx_info` using a plain dict:

```python
idx_to_iloc = {v: i for i, v in enumerate(gene_idx_info_index)}
```

When two or more genes share the same TSS peak — e.g. a gene and its
antisense lncRNA (`FMR1` / `FMR1-AS1`), a gene and a read-through
transcript, or overlapping isoforms — the dict keeps only the **last**
entry for that peak index and silently drops all earlier ones.

In practice this causes a measurable fraction of genes to disappear from
`gene_idx_info` after `drop_zero_atpm` filtering, even when every peak
in the zarr has non-zero aTPM (so the filtering step itself removes
nothing). In our MDM dataset 19 out of 452 differential genes were
silently lost this way.

## Fix

Replace the dict with a `defaultdict(list)` that accumulates **all**
positions in `gene_idx_info` for a given peak index, then emits one row
per gene:

```python
idx_to_ilocs = defaultdict(list)
for i, v in enumerate(gene_idx_info_index):
    idx_to_ilocs[v].append(i)
for idx_non_zero_atpm, idx in enumerate(atpm_nonzero_idx):
    if idx in idx_to_ilocs:
        for pos in idx_to_ilocs[idx]:
            gene_idx_info_drop_zero_atpm.append(...)
```

## Additional fixes in the same file

- **`_peaks` index alignment**: add `reset_index(drop=True)` after the
  `iloc[atpm_nonzero_idx]` slice so that subsequent positional lookups
  into `_peaks` remain correct.
- **`InferenceRegionMotifDataset`**: skip genes whose chromosome is not
  in `input_chromosomes` before attempting to build a window, preventing
  silent inclusion of held-out-chromosome genes in the wrong split.